### PR TITLE
Fix dialog listener name

### DIFF
--- a/app/src/main/java/com/deyvitineo/tdee/dialogs/ShowUpdateMessageDialog.java
+++ b/app/src/main/java/com/deyvitineo/tdee/dialogs/ShowUpdateMessageDialog.java
@@ -57,7 +57,7 @@ public class ShowUpdateMessageDialog extends AppCompatDialogFragment {
             listener = (MessageShownListener) context;
         } catch (ClassCastException e) {
             throw new ClassCastException(context.toString()
-                    + " must implement AddCityDialogListener");
+                    + " must implement MessageShownListener");
         }
     }
 


### PR DESCRIPTION
## Summary
- fix incorrect class cast exception message in ShowUpdateMessageDialog

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848c5d266bc83279d61ead525d8e95a