### PR TITLE
Fix activity label text

### DIFF
--- a/app/src/main/java/com/deyvitineo/tdee/util/SpinnerDataGenerators.java
+++ b/app/src/main/java/com/deyvitineo/tdee/util/SpinnerDataGenerators.java
@@ -18,7 +18,7 @@ public class SpinnerDataGenerators {
 
     public static ArrayList<String> getActivityLevels() {
         ArrayList<String> arrayList = new ArrayList<>();
-        arrayList.add("Sedentary (OfficeJob)");
+        arrayList.add("Sedentary (Office Job)");
         arrayList.add("Light (Exercise 1-2 days/week)");
         arrayList.add("Moderate (Exercise 3-5 days/week)");
         arrayList.add("Heavy (Exercise 6-7 days/week)");


### PR DESCRIPTION
## Summary
- fix "OfficeJob" label for the sedentary activity level

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6848c90522ac8327934afb488bb8527a